### PR TITLE
Add recent activities dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -110,6 +110,18 @@
     </div>
   </div>
 
+  <h2>Dashboard</h2>
+  <p>Durchschnittliche Distanz der letzten 2&nbsp;Wochen:
+     {{ "%.2f"|format(avg_distance) }}&nbsp;km</p>
+  <table class="history">
+    <tr><th>Datum</th><th>Typ</th><th>Distanz (km)</th><th>Notizen</th></tr>
+    {% for a in recent_activities %}
+    <tr>
+      <td>{{ a.date }}</td><td>{{ a.type }}</td><td>{{ a.distance }}</td><td>{{ a.notes }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+
   <h2>Aktuelle Aktivitäten</h2>
   <table class="history">
     <tr><th>Datum</th><th>Typ</th><th>Distanz (km)</th><th>Notizen</th></tr>


### PR DESCRIPTION
## Summary
- fetch and compute recent activities and average distance
- display the last two weeks and average on the index page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685eddadff748326abfdbbc6ba38fcc4