### PR TITLE
Add README with Garmin key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Sporttracker
+
+## Setup
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+2. Set the `GARMIN_KEY` environment variable. Generate a key with:
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+Then export it:
+```bash
+export GARMIN_KEY=your_generated_key  # on Windows use `set`
+```
+3. Run the application:
+```bash
+python app.py
+```


### PR DESCRIPTION
## Summary
- document how to generate and set the `GARMIN_KEY` environment variable

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_685ee5a58aa48326972058b25d930600